### PR TITLE
Disable seccomp for  #1283

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -165,7 +165,7 @@ echo "V4L2_DEVICES:  $V4L2_DEVICES"
 # run the container
 sudo xhost +si:localuser:root
 
-sudo docker run --runtime nvidia -it --rm --network host -e DISPLAY=$DISPLAY \
+sudo docker run --runtime nvidia -it --rm --security-opt  seccomp=unconfined --network host -e DISPLAY=$DISPLAY \
     -v /tmp/.X11-unix/:/tmp/.X11-unix \
     -v /tmp/argus_socket:/tmp/argus_socket \
     -v /etc/enctune.conf:/etc/enctune.conf \


### PR DESCRIPTION
Closes #1283.

New versions of docker have a default seccomp profile that were preventing the container from running.  Disabling seccomp as part of docker run command. 